### PR TITLE
fix(deployments): handle spaceId scheduler change

### DIFF
--- a/src/app/space/create/deployments/deployments.component.spec.ts
+++ b/src/app/space/create/deployments/deployments.component.spec.ts
@@ -91,13 +91,13 @@ describe('DeploymentsComponent', () => {
     let resourceUsageComponents = this.tested.queryAll(By.directive(FakeDeploymentsResourceUsageComponent));
     expect(resourceUsageComponents.length).toEqual(1);
     let resourceUsageComponent = resourceUsageComponents[0].componentInstance;
-    expect(resourceUsageComponent.environments).toBe(mockEnvironments);
+    expect(resourceUsageComponent.environments).toBe(this.testedDirective.environments);
 
     let appsComponents = this.tested.queryAll(By.directive(FakeDeploymentAppsComponent));
     expect(appsComponents.length).toEqual(1);
     let appsComponent = appsComponents[0].componentInstance;
-    expect(appsComponent.environments).toBe(mockEnvironments);
-    expect(appsComponent.applications).toBe(mockApplications);
+    expect(appsComponent.environments).toBe(this.testedDirective.environments);
+    expect(appsComponent.applications).toBe(this.testedDirective.applications);
   });
 
 });

--- a/src/app/space/create/deployments/deployments.component.ts
+++ b/src/app/space/create/deployments/deployments.component.ts
@@ -1,7 +1,12 @@
 import { Component, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 
 import { Spaces } from 'ngx-fabric8-wit';
-import { Observable, Subscription } from 'rxjs';
+import {
+  Observable,
+  ReplaySubject,
+  Subject,
+  Subscription
+} from 'rxjs';
 
 import { Environment } from './models/environment';
 import { DeploymentsService } from './services/deployments.service';
@@ -15,8 +20,8 @@ import { DeploymentsService } from './services/deployments.service';
 export class DeploymentsComponent implements OnDestroy, OnInit {
 
   spaceId: Observable<string>;
-  environments: Observable<Environment[]>;
-  applications: Observable<string[]>;
+  environments: Subject<Environment[]>;
+  applications: Subject<string[]>;
 
   private subscriptions: Subscription[] = [];
 
@@ -25,6 +30,9 @@ export class DeploymentsComponent implements OnDestroy, OnInit {
     private deploymentsService: DeploymentsService
   ) {
     this.spaceId = this.spaces.current.first().map(space => space.id);
+
+    this.environments = new ReplaySubject<Environment[]>(1);
+    this.applications = new ReplaySubject<string[]>(1);
   }
 
   ngOnDestroy(): void {
@@ -40,11 +48,8 @@ export class DeploymentsComponent implements OnDestroy, OnInit {
   private updateResources(): void {
     this.subscriptions.push(
       this.spaceId.subscribe(spaceId => {
-        this.environments =
-          this.deploymentsService.getEnvironments(spaceId);
-
-        this.applications =
-          this.deploymentsService.getApplications(spaceId);
+        this.deploymentsService.getEnvironments(spaceId).subscribe(this.environments);
+        this.deploymentsService.getApplications(spaceId).subscribe(this.applications);
       })
     );
   }


### PR DESCRIPTION
do not allow component "applications" and "environments" properties to remain undefined until a
spaceId is observed

