### PR TITLE
fix(link): support for auth-native openshift linking

### DIFF
--- a/src/app/getting-started/getting-started.component.ts
+++ b/src/app/getting-started/getting-started.component.ts
@@ -78,6 +78,18 @@ export class GettingStartedComponent implements OnDestroy, OnInit {
   }
 
   ngOnInit(): void {
+
+
+    // when both github and openshift is being linked together,
+    // openshift is linked first and then user is redirected
+    // to the https://openshift.io/_gettingstarted?link=https://github.com
+    // the following code will 'read' the link param and then
+    // call the auth service's LINK API with the required authorization header.
+    let linkRedirect = this.getRequestParam('link');
+    if !(linkRedirect === null) && (linkRedirect === 'https://github.com') {
+      this.providerService.linkGitHub(window.location.origin + '/_gettingstarted?wait=true');
+    }
+
     // Route to home if registration is complete.
     this.userService.loggedInUser
       .map(user => {
@@ -148,11 +160,11 @@ export class GettingStartedComponent implements OnDestroy, OnInit {
    */
   connectAccounts(): void {
     if (this.authGitHub && !this.gitHubLinked && this.authOpenShift && !this.openShiftLinked) {
-      this.providerService.linkAll(window.location.origin + '/_gettingstarted?wait=true');
+      this.providerService.linkAll(this.loggedInUser.attributes.cluster , window.location.origin + '/_gettingstarted?wait=true');
     } else if (this.authGitHub && !this.gitHubLinked) {
       this.providerService.linkGitHub(window.location.origin + '/_gettingstarted?wait=true');
     } else if (this.authOpenShift && !this.openShiftLinked) {
-      this.providerService.linkOpenShift(window.location.origin + '/_gettingstarted?wait=true');
+      this.providerService.linkOpenShift(this.loggedInUser.attributes.cluster, window.location.origin + '/_gettingstarted?wait=true');
     }
   }
 


### PR DESCRIPTION
Scenarios:

1. Both OpenShift & Github is unlinked
2. Only Github is unlinked.
3. Only OpenShift is unlinked.

How to unlink?

```
curl -i -H "Authorization: Bearer $AUTH_TOKEN" -X DELETE https://auth.prod-preview.openshift.io/api/token?for=https://github.com

curl -i -H "Authorization: Bearer $AUTH_TOKEN" -X DELETE https://auth.prod-preview.openshift.io/api/token?for=https://api.free-stg.openshift.com/
```